### PR TITLE
Add Localizations

### DIFF
--- a/src/main/resources/assets/mcframes/lang/en_US.lang
+++ b/src/main/resources/assets/mcframes/lang/en_US.lang
@@ -1,2 +1,5 @@
+tile.relocation.blockmovingrow.name=Moving Block
+
 tile.mcframes.frame.name=Frame
+tile.mcframes.motor.name=Debug Frame Motor
 tile.mcframes.motor|0.name=Debug Frame Motor


### PR DESCRIPTION
This adds some missing localizations for unlocalized names returned by the ItemStack-insensitive version of `Item.getUnlocalizedName()`.
Relevant for the Item/Block stats introduced in https://github.com/GTNewHorizons/Hodgepodge/pull/398.